### PR TITLE
Zero out the maze matrix

### DIFF
--- a/source/generator/generator.cxx
+++ b/source/generator/generator.cxx
@@ -29,7 +29,11 @@ int **Generator::initializeMatrix() {
   /// Creating empty maze
   auto empty_maze = new int *[dimensions_];
   for (auto i = 0; i < dimensions_; i++)
-    empty_maze[i] = new int[dimensions_];
+  {
+      empty_maze[i] = new int[dimensions_];
+      for (auto j = 0; j < dimensions_; j++)
+          empty_maze[i][j] = 0;
+  }
 
   return empty_maze;
 }


### PR DESCRIPTION
...because occasionally there were weird negative values that couldn't be interpreted as tile indexes. There's probably an obvious more efficient way to do this but I couldn't program C++ if my life depended on it.

Thanks for the generator!